### PR TITLE
#560021 リスタートを繰り返すと動作が遅くなるバグの対応

### DIFF
--- a/ShinobiSHift_Game/ShinobiSHift_Game/Program.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/Program.cs
@@ -19,7 +19,7 @@ namespace ShinobiSHift_Game
             //動作確認用           
             Application.Run(new ShinobiShiftBooting());
            // Application.Run(new ShinobiShiftRule());
-            Application.Run(new ShinobiShiftInAction());
+            //Application.Run(new ShinobiShiftInAction());
             //Application.Run(new ShinobiShiftGameOver());
             //Application.Run(new ShinobiShiftClear());
 

--- a/ShinobiSHift_Game/ShinobiSHift_Game/ShinobiShiftInAction.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/ShinobiShiftInAction.cs
@@ -72,7 +72,8 @@ namespace ShinobiSHift_Game
 
             if (barriers.Any(x => Player.Bounds.IntersectsWith(x.PictureBox.Bounds)))//【消さない方がいい】Playerと障害物の衝突判定
             {
-                timer1.Stop();
+                allTimerStop();
+
                 ShinobiShiftGameOver gameOverForm = new ShinobiShiftGameOver(score);//スコアをGameOverフォームに渡してる
                 gameOverForm.Show();
                 this.Hide();
@@ -81,7 +82,8 @@ namespace ShinobiSHift_Game
 
             if (score >= 20000)
             {
-                timer1.Stop(); // タイマー停止
+                allTimerStop();
+
                 this.Hide();   // 現在のフォームを隠す
 
                 ShinobiShiftClear clearForm = new ShinobiShiftClear();
@@ -107,6 +109,17 @@ namespace ShinobiSHift_Game
                     Player.Size = new Size(49, 62);
                 }
             }
+        }
+
+        private void allTimerStop()//【消さない方がいい】タイマーを停止し、リソースを開放する
+        {
+            timer1.Stop();
+            timer1.Dispose();
+            timer1 = null;
+
+            moveTimer.Stop();
+            moveTimer.Dispose();
+            moveTimer = null;
         }
     }
 }


### PR DESCRIPTION
Timerが多重に宣言されていたため動作が遅くなっていました。
allTimerStomメソッドを追加してTimerを停止、Disposeでリソースを開放してnullにすることでTimerを完全に片付ける機能を実装しました。