### PR TITLE
#560836 スコア表記のコントロールの変更・画面遷移設定の変更

### DIFF
--- a/ShinobiSHift_Game/ShinobiSHift_Game/ClearForm.Designer.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/ClearForm.Designer.cs
@@ -33,9 +33,9 @@
             this.button1 = new System.Windows.Forms.Button();
             this.Player = new System.Windows.Forms.PictureBox();
             this.ScorePanel = new System.Windows.Forms.Panel();
+            this.ClearBGM = new AxWMPLib.AxWindowsMediaPlayer();
             this.label1 = new System.Windows.Forms.Label();
             this.ClearRecord = new System.Windows.Forms.Label();
-            this.ClearBGM = new AxWMPLib.AxWindowsMediaPlayer();
             ((System.ComponentModel.ISupportInitialize)(this.Player)).BeginInit();
             this.ScorePanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ClearBGM)).BeginInit();
@@ -50,7 +50,7 @@
             this.button2.TabIndex = 13;
             this.button2.Text = "ReStart";
             this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button2_Click);
+            this.button2.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button2_Click);
             // 
             // button1
             // 
@@ -61,7 +61,7 @@
             this.button1.TabIndex = 12;
             this.button1.Text = "Home";
             this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.button1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button1_Click);
             // 
             // Player
             // 
@@ -80,6 +80,16 @@
             this.ScorePanel.Name = "ScorePanel";
             this.ScorePanel.Size = new System.Drawing.Size(1200, 30);
             this.ScorePanel.TabIndex = 10;
+            // 
+            // ClearBGM
+            // 
+            this.ClearBGM.Enabled = true;
+            this.ClearBGM.Location = new System.Drawing.Point(953, -16);
+            this.ClearBGM.Name = "ClearBGM";
+            this.ClearBGM.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("ClearBGM.OcxState")));
+            this.ClearBGM.Size = new System.Drawing.Size(219, 43);
+            this.ClearBGM.TabIndex = 15;
+            this.ClearBGM.Visible = false;
             // 
             // label1
             // 
@@ -103,16 +113,6 @@
             this.ClearRecord.Size = new System.Drawing.Size(99, 39);
             this.ClearRecord.TabIndex = 14;
             this.ClearRecord.Text = "label3";
-            // 
-            // ClearBGM
-            // 
-            this.ClearBGM.Enabled = true;
-            this.ClearBGM.Location = new System.Drawing.Point(953, -16);
-            this.ClearBGM.Name = "ClearBGM";
-            this.ClearBGM.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("ClearBGM.OcxState")));
-            this.ClearBGM.Size = new System.Drawing.Size(219, 43);
-            this.ClearBGM.TabIndex = 15;
-            this.ClearBGM.Visible = false;
             // 
             // ClearForm
             // 

--- a/ShinobiSHift_Game/ShinobiSHift_Game/ClearForm.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/ClearForm.cs
@@ -13,6 +13,7 @@ namespace ShinobiLeap_Game
             InitializeComponent();
             finalScore = score;
             this.FormClosing += ShinobiShiftClear_FormClosing;
+           
         }
 
         private void ShinobiLeapClear_Load(object sender, EventArgs e)
@@ -25,7 +26,7 @@ namespace ShinobiLeap_Game
             ClearBGM.settings.volume = 1;//音量
         }
 
-        private void button2_Click(object sender, EventArgs e)
+        private void button2_Click(object sender, MouseEventArgs e)
         {
             PlayForm InActionForm = new PlayForm();
             // 新しいフォームを表示
@@ -35,8 +36,9 @@ namespace ShinobiLeap_Game
             ClearBGM.Ctlcontrols.stop();// BGMを止める
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void button1_Click(object sender, MouseEventArgs e)
         {
+            ActiveControl = null;
             // 新しいフォームを作成
             StartForm StartForm = new StartForm();
             // 新しいフォームを表示

--- a/ShinobiSHift_Game/ShinobiSHift_Game/EndlessForm.Designer.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/EndlessForm.Designer.cs
@@ -31,9 +31,9 @@
             this.components = new System.ComponentModel.Container();
             this.Player = new System.Windows.Forms.PictureBox();
             this.ScorePanel = new System.Windows.Forms.Panel();
-            this.ScoreRecord = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.ScoreRecord = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.Player)).BeginInit();
             this.ScorePanel.SuspendLayout();
             this.SuspendLayout();
@@ -58,14 +58,6 @@
             this.ScorePanel.Size = new System.Drawing.Size(1200, 30);
             this.ScorePanel.TabIndex = 7;
             // 
-            // ScoreRecord
-            // 
-            this.ScoreRecord.Font = new System.Drawing.Font("Impact", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ScoreRecord.Location = new System.Drawing.Point(99, 3);
-            this.ScoreRecord.Name = "ScoreRecord";
-            this.ScoreRecord.Size = new System.Drawing.Size(100, 22);
-            this.ScoreRecord.TabIndex = 1;
-            // 
             // label1
             // 
             this.label1.AutoSize = true;
@@ -75,6 +67,15 @@
             this.label1.Size = new System.Drawing.Size(71, 26);
             this.label1.TabIndex = 0;
             this.label1.Text = "Score :";
+            // 
+            // ScoreRecord
+            // 
+            this.ScoreRecord.Font = new System.Drawing.Font("Impact", 15.75F, System.Drawing.FontStyle.Italic);
+            this.ScoreRecord.Location = new System.Drawing.Point(89, 0);
+            this.ScoreRecord.Name = "ScoreRecord";
+            this.ScoreRecord.Size = new System.Drawing.Size(100, 22);
+            this.ScoreRecord.TabIndex = 2;
+            this.ScoreRecord.Text = "label2";
             // 
             // EndlessForm
             // 
@@ -97,8 +98,8 @@
 
         private System.Windows.Forms.PictureBox Player;
         private System.Windows.Forms.Panel ScorePanel;
-        internal System.Windows.Forms.TextBox ScoreRecord;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Timer timer1;
+        private System.Windows.Forms.Label ScoreRecord;
     }
 }

--- a/ShinobiSHift_Game/ShinobiSHift_Game/PlayForm.Designer.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/PlayForm.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PlayForm));
             this.ScorePanel = new System.Windows.Forms.Panel();
-            this.ScoreRecord = new System.Windows.Forms.TextBox();
+            this.PlayBGM = new AxWMPLib.AxWindowsMediaPlayer();
             this.label1 = new System.Windows.Forms.Label();
             this.Player = new System.Windows.Forms.PictureBox();
             this.pictureBox2 = new System.Windows.Forms.PictureBox();
@@ -39,34 +39,36 @@
             this.pictureBox4 = new System.Windows.Forms.PictureBox();
             this.pictureBox5 = new System.Windows.Forms.PictureBox();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
-            this.PlayBGM = new AxWMPLib.AxWindowsMediaPlayer();
+            this.ScoreRecord = new System.Windows.Forms.Label();
             this.ScorePanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.PlayBGM)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.Player)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.PlayBGM)).BeginInit();
             this.SuspendLayout();
             // 
             // ScorePanel
             // 
             this.ScorePanel.BackColor = System.Drawing.Color.White;
-            this.ScorePanel.Controls.Add(this.PlayBGM);
             this.ScorePanel.Controls.Add(this.ScoreRecord);
+            this.ScorePanel.Controls.Add(this.PlayBGM);
             this.ScorePanel.Controls.Add(this.label1);
             this.ScorePanel.Location = new System.Drawing.Point(0, 334);
             this.ScorePanel.Name = "ScorePanel";
             this.ScorePanel.Size = new System.Drawing.Size(1200, 30);
             this.ScorePanel.TabIndex = 6;
             // 
-            // ScoreRecord
+            // PlayBGM
             // 
-            this.ScoreRecord.Font = new System.Drawing.Font("Impact", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ScoreRecord.Location = new System.Drawing.Point(99, 3);
-            this.ScoreRecord.Name = "ScoreRecord";
-            this.ScoreRecord.Size = new System.Drawing.Size(100, 22);
-            this.ScoreRecord.TabIndex = 1;
+            this.PlayBGM.Enabled = true;
+            this.PlayBGM.Location = new System.Drawing.Point(953, -13);
+            this.PlayBGM.Name = "PlayBGM";
+            this.PlayBGM.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("PlayBGM.OcxState")));
+            this.PlayBGM.Size = new System.Drawing.Size(219, 43);
+            this.PlayBGM.TabIndex = 7;
+            this.PlayBGM.Visible = false;
             // 
             // label1
             // 
@@ -128,15 +130,14 @@
             // 
             this.timer1.Tick += new System.EventHandler(this.Timer1_Tick);
             // 
-            // PlayBGM
+            // ScoreRecord
             // 
-            this.PlayBGM.Enabled = true;
-            this.PlayBGM.Location = new System.Drawing.Point(953, -13);
-            this.PlayBGM.Name = "PlayBGM";
-            this.PlayBGM.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("PlayBGM.OcxState")));
-            this.PlayBGM.Size = new System.Drawing.Size(219, 43);
-            this.PlayBGM.TabIndex = 7;
-            this.PlayBGM.Visible = false;
+            this.ScoreRecord.Font = new System.Drawing.Font("Impact", 15.75F, System.Drawing.FontStyle.Italic);
+            this.ScoreRecord.Location = new System.Drawing.Point(89, 0);
+            this.ScoreRecord.Name = "ScoreRecord";
+            this.ScoreRecord.Size = new System.Drawing.Size(100, 22);
+            this.ScoreRecord.TabIndex = 8;
+            this.ScoreRecord.Text = "label2";
             // 
             // PlayForm
             // 
@@ -151,12 +152,12 @@
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.space);
             this.ScorePanel.ResumeLayout(false);
             this.ScorePanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.PlayBGM)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.Player)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.PlayBGM)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -172,7 +173,7 @@
         private System.Windows.Forms.Panel ScorePanel;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Timer timer1;
-        internal System.Windows.Forms.TextBox ScoreRecord;
         private AxWMPLib.AxWindowsMediaPlayer PlayBGM;
+        private System.Windows.Forms.Label ScoreRecord;
     }
 }

--- a/ShinobiSHift_Game/ShinobiSHift_Game/SelectForm.Designer.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/SelectForm.Designer.cs
@@ -57,7 +57,7 @@
             this.button1.TabIndex = 2;
             this.button1.Text = "Endless";
             this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.button1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button1_Click);
             // 
             // button2
             // 
@@ -68,7 +68,7 @@
             this.button2.TabIndex = 3;
             this.button2.Text = "Normal";
             this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button2_Click);
+            this.button2.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button2_Click);
             // 
             // ScorePanel
             // 

--- a/ShinobiSHift_Game/ShinobiSHift_Game/SelectForm.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/SelectForm.cs
@@ -31,7 +31,7 @@ namespace ShinobiSHift_Game
             Player2.Size = new Size(49, 62);
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void button1_Click(object sender, MouseEventArgs e)
         {
             // 新しいフォームを作成
             EndlessRuleForm EndlessRuleForm = new EndlessRuleForm();
@@ -43,7 +43,7 @@ namespace ShinobiSHift_Game
             this.Hide();
         }
 
-        private void button2_Click(object sender, EventArgs e)
+        private void button2_Click(object sender, MouseEventArgs e)
         {
             // 新しいフォームを作成
             RuleForm RuleForm = new RuleForm();

--- a/ShinobiSHift_Game/ShinobiSHift_Game/StartForm.Designer.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/StartForm.Designer.cs
@@ -60,7 +60,7 @@
             this.button1.TabIndex = 1;
             this.button1.Text = "Start";
             this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.button1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button1_Click);
             // 
             // Player
             // 

--- a/ShinobiSHift_Game/ShinobiSHift_Game/StartForm.cs
+++ b/ShinobiSHift_Game/ShinobiSHift_Game/StartForm.cs
@@ -32,7 +32,7 @@ namespace ShinobiLeap_Game
             StartBGM.settings.volume = 1;//音量
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void button1_Click(object sender, MouseEventArgs e)
         {
             // BGMを止める
             StartBGM.Ctlcontrols.stop();


### PR DESCRIPTION
1. ノーマルモード・エンドレスモードのプレイ画面におけるスコア表記のコントロールを、テキストボックスからラベルに変更するよう実装しました
2. クリア画面において、クリア画面に遷移後Spaceキーを押してもすぐにHome画面に遷移しないよう実装しました
3. スタート画面において、Spaceキーを押してもモード選択画面に遷移しないよう実装しました
4. モード選択画面において、Spaceキーを押してもルール画面（エンドレスモード）に遷移しないよう実装しました